### PR TITLE
Add option to disable OpenMP.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ def check_for_openmp():
 
     This routine is adapted from yt, thanks to Nathan
     Goldbaum. See https://github.com/pynbody/pynbody/issues/124"""
+
+    if os.getenv('DISABLE_OPENMP') is not None:
+        return False
+
     # Create a temporary directory
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()


### PR DESCRIPTION
It is not a good idea to have OpenMP in a Python extension.
The behavior is not always well defined.

For safety in a conda package we shall disable OpenMP it only
provides a baseline performance, but it will work instead of crash.