### PR TITLE
Progress counter & small 'fix' to T0 and gamma fit

### DIFF
--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -665,6 +665,7 @@ class Spectra(object):
             return result
         for nn in xrange(1,nsegments):
             tresult =  self._interpolate_single_file(nn, elem, ion, ll, get_tau)
+            print("Interpolation %.1f percent done" % (100*nn/nsegments))
             #Add new file
             result += tresult
             del tresult

--- a/fake_spectra/tempdens.py
+++ b/fake_spectra/tempdens.py
@@ -28,7 +28,7 @@ def mean_density(hub, redshift, omegab=0.0465):
 
 def fit_temp_dens_relation(logoverden, logT):
     """Fit a temperature density relation."""
-    ind = np.where((logoverden <  1.0) * (logT < 5.0))
+    ind = np.where((0.1 < logoverden) * (logoverden <  1.0) * (0.1 < logT) * (logT < 5.0))
 
     logofor = logoverden[ind]
     logtfor = logT[ind]

--- a/fake_spectra/tempdens.py
+++ b/fake_spectra/tempdens.py
@@ -28,7 +28,7 @@ def mean_density(hub, redshift, omegab=0.0465):
 
 def fit_temp_dens_relation(logoverden, logT):
     """Fit a temperature density relation."""
-    ind = np.where((0.1 < logoverden) * (logoverden <  1.0) * (0.1 < logT) * (logT < 5.0))
+    ind = np.where((0 < logoverden) * (logoverden <  1.0) * (0.1 < logT) * (logT < 5.0))
 
     logofor = logoverden[ind]
     logtfor = logT[ind]


### PR DESCRIPTION
This PR contains the progress counter we discussed a while back, and a small fix to the T0 and gamma fit script to still give sensible results if the temp and or density arrays contain 0s (which lead to -inf in the log10 arrrays).