### PR TITLE
Patch 5

### DIFF
--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -80,7 +80,7 @@ class Spectra:
                      kernel (a good back up for large Arepo simulations) "quintic" for a quintic SPh kernel as used in modern SPH
                      and "cubic" or "sph" for an old-school cubic SPH kernel.
     """
-    def __init__(self,num, base,cofm, axis, res=1., cdir=None, savefile="spectra.hdf5", savedir=None, reload_file=False, snr = [0.], CE=[0.],spec_res = 0,load_halo=False, units=None, sf_neutral=True,quiet=False, load_snapshot=True, gasprop=None, gasprop_args=None, kernel=None):
+    def __init__(self,num, base,cofm, axis, res=1., cdir=None, savefile="spectra.hdf5", savedir=None, reload_file=False, snr = None, CE= None,spec_res = 0,load_halo=False, units=None, sf_neutral=True,quiet=False, load_snapshot=True, gasprop=None, gasprop_args=None, kernel=None):
         #Present for compatibility. Functionality moved to HaloAssignedSpectra
         _= load_halo
         self.num = num

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -107,8 +107,9 @@ class Spectra:
         self.num_important = {}
         self.discarded=0
         self.npart=0
-        #If greater than zero, will add noise to spectra when they are loaded.You should pass an array with the size of ndla (each spectrum has a different snr)
+        #If is None, will add noise to spectra when they are loaded.You should pass an array with the size of spectra number.
         self.snr = snr
+        # The stdev for calculating Continuum Error. You should pass an array with the same size as snr.
         self.CE = CE
         self.spec_res = spec_res
         self.cdir = cdir
@@ -360,7 +361,7 @@ class Spectra:
             lines = np.shape(flux)[0]
         #This is to get around the type rules
         if lines == 1:
-            #This ensures that we always get the same noise gor the same spectrum and is differen from seed for rand noise
+            #This ensures that we always get the same noise for the same spectrum and is differen from seed for rand noise
             np.random.seed(2*spec_num)
             delta = np.random.normal(0, CE[spec_num])
             
@@ -822,7 +823,7 @@ class Spectra:
         phys = self.dvbin/self.velfac*self.rscale
         return colden/phys
 
-    def get_tau(self, elem, ion,line, number = -1, force_recompute=False, noise=True, cont_noise = True):
+    def get_tau(self, elem, ion,line, number = -1, force_recompute=False):
         """Get the optical depth in each pixel along the sightline for a given line."""
         try:
             if force_recompute:
@@ -842,10 +843,10 @@ class Spectra:
             if np.any(corrflux <= 0):
                 raise Exception
             tau = - np.log(corrflux)
-        if noise and np.any(self.snr) > 0:
+        if snr is not None :
             tau = self.add_noise(self.snr, tau, number)
             
-            if cont_noise :
+            if CE is not None :
                 tau = self.add_cont_error(CE = self.CE, tau = tau, spec_num = number)
 
         return tau

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -107,9 +107,9 @@ class Spectra:
         self.num_important = {}
         self.discarded=0
         self.npart=0
-        #If is None, will add noise to spectra when they are loaded.You should pass an array with the size of spectra number.
+        #If is not None, will add noise to spectra when they are loaded.You should pass an array with the size of spectra number.
         self.snr = snr
-        # The stdev for calculating Continuum Error. You should pass an array with the same size as snr.
+        # The stdev for calculating Continuum Error. The same comments as snr.
         self.CE = CE
         self.spec_res = spec_res
         self.cdir = cdir

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -349,7 +349,7 @@ class Spectra:
         return tau
 
 
-    def add_cont_error(self, CE, tau, spec_num):
+    def add_cont_error(self, CE, tau, spec_num, u_delta=0.6, l_delta=-0.6):
         """Compute a Gaussian noise vector from the flux variance and the CE. It is due to continuum fitting error
         in observations"""
 
@@ -363,8 +363,9 @@ class Spectra:
             #This ensures that we always get the same noise gor the same spectrum and is differen from seed for rand noise
             np.random.seed(2*spec_num)
             delta = np.random.normal(0, CE[spec_num])
-
-            while (delta <-0.6) or (delta > 0.6):
+            
+            # Use lower and upper limit of delta from 2sigma for the highest CE in the survey
+            while (delta < l_delta) or (delta > u_delta):
                 delta = np.random.normal(0, CE[spec_num])
 
             flux /= (1.0 + delta)
@@ -378,7 +379,7 @@ class Spectra:
                 np.random.seed(2*ii)
                 delta[ii] = np.random.normal(0, CE[ii])
 
-                while (delta[ii] < -0.6) or (delta[ii] > 0.6) :
+                while (delta[ii] < l_delta) or (delta[ii] > u_delta) :
                     delta[ii] = np.random.normal(0, CE[ii])
 
                 flux[ii] /= (1.0 + delta[ii])
@@ -845,7 +846,7 @@ class Spectra:
             tau = self.add_noise(self.snr, tau, number)
             
             if cont_noise :
-                tau = self.add_cont_error(self.CE, tau, number)
+                tau = self.add_cont_error(CE = self.CE, tau = tau, spec_num = number)
 
         return tau
     


### PR DESCRIPTION
Hi Simeon,

I just made some minor changes to :

1. random noise calculation : 
     In observations, this random noise is different for each sightline (different observing time for each spectra, I guess), so instead of a single snr in the argument of spectra() the code needs an array.  

2. Continuum fitting error : 
 
  I just used the continuum error modelling which  Drew has used in his observations.

I tired to keep the code general to be used for any observation. For instance, snr and CE are the random variables should be modelled from observation, and then to be passed to fake_spectra. If no noise is needed, the default values will not add any to the spectra.

I have run the it on some snapshots and seem to be working.
Please, let me know If something is wrong.