### PR TITLE
Voigt fitting and NHI-b cutoff fitting

### DIFF
--- a/fake_spectra/fluxstatistics.py
+++ b/fake_spectra/fluxstatistics.py
@@ -82,6 +82,7 @@ def flux_power(tau, vmax, spec_res = 8, mean_flux_desired=None, window=True):
         mean_flux_desired = np.mean(np.exp(-tau))
     (nspec, npix) = np.shape(tau)
     mean_flux_power = np.zeros(npix//2+1, dtype=tau.dtype)
+    # compute in batches, purely for computational efficiency
     for i in range(10):
         end = min((i+1)*nspec//10, nspec)
         dflux=np.exp(-scale*tau[i*nspec//10:end])/mean_flux_desired - 1.

--- a/fake_spectra/voigtfit.py
+++ b/fake_spectra/voigtfit.py
@@ -318,16 +318,16 @@ def get_voigt_systems(taus, dvbin, elem="H", ion=1, line=1215, verbose=False, cl
         return n_vals, b_params
     return n_vals
 
-def _opt_power_fit(inputs, lb_params, ln_vals):
-    """Fit log b = log b_0  + (Gamma -1 ) * ( log NHI - log NHI,0)
-    for log b_0 and Gamma-1. log NHI, 0 = 13.6"""
-    lb0 = inputs[0]
-    gamm1 = inputs[1]
-    return np.sum((lb_params - lb0 + gamm1 * (ln_vals - 13.6))**2)
-
 def _power_fit(ln, lb0, gamm1):
     """A power law fit given some parameters"""
     return lb0 + gamm1 * (ln - 13.6)
+
+def _opt_power_fit(inputs, lb_params, ln_vals):
+    """Fit log b = log b_0  + (Gamma-1) * (log NHI - log NHI,0)
+    for log b_0 and Gamma-1. log NHI,0 = 13.6"""
+    lb0 = inputs[0]
+    gamm1 = inputs[1]
+    return np.sum(abs(lb_params - _power_fit(ln_vals, lb0, gamm1)))
 
 def get_b_param_dist(taus, dvbin, elem="H", ion=1, line=1215, tol=0.05):
     """Get the power law betweeen the 'minimum' b parameter and column density,

--- a/fake_spectra/voigtfit.py
+++ b/fake_spectra/voigtfit.py
@@ -41,12 +41,12 @@ class Profiles(object):
         #Set things up
         self.tau = tau
         #In km/s (the units of dvbin)
-        self.wavelengths = np.arange(0,np.size(tau))*self.dvbin
+        self.wavelengths = np.arange(0, np.size(tau))*self.dvbin
         #Wavelength difference from central region
         midpt = np.size(self.wavelengths)//2
         self.lambda_diff = (self.wavelengths - midpt*self.dvbin)
 
-    def do_fit(self, tol=1e-4, signif = 0.9, sattau = 4):
+    def do_fit(self, tol=1e-4, signif=0.9, sattau=4):
         """Do the fit.
         tol - stop peak finding when the largest peak is tol * max(1,max(self.tau))
         As we iteratively remove peaks, small peaks are increasingly likely to just be fitting errors
@@ -57,12 +57,12 @@ class Profiles(object):
         fitted_tau = np.array(self.tau)
         #We do not care about very small peaks; this includes both peaks which are small in absolute value
         #and peaks which are small in a relative sense.
-        realtol = tol * np.max([1,np.max(self.tau)])
+        realtol = tol * np.max([1, np.max(self.tau)])
         #Initial mask includes the whole spectrum
         mask = np.where(fitted_tau > -1)
         #Do the fit iteratively, stopping when the largest peak is likely unimportant.
         while np.max(fitted_tau[mask]) > realtol:
-            (fitted_tau, mean, amplitude, stddev)=self.iterate_new_spectrum(fitted_tau, mask=mask)
+            (fitted_tau, mean, amplitude, stddev) = self.iterate_new_spectrum(fitted_tau, mask=mask)
             #We only want to fit to regions that are not already saturated in the fit.
             self.means.append(mean)
             self.amplitudes.append(amplitude)
@@ -70,23 +70,23 @@ class Profiles(object):
             mask = np.where(self.profile_multiple(self.stddev, self.means, self.amplitudes) < sattau)
         #Do a global re-fit of all peaks
         inputs = np.hstack([self.stddev[:2], self.means[:2], self.amplitudes[:2]])
-        result = optimize.minimize(self.fun_min_multiple,inputs, tol=realtol, method='Nelder-Mead')
-        total = np.min([2,np.size(self.stddev)])
-        for maxpk in range(3,np.size(self.stddev)+1):
+        result = optimize.minimize(self.fun_min_multiple, inputs, tol=realtol, method='Nelder-Mead')
+        total = np.min([2, np.size(self.stddev)])
+        for maxpk in range(3, np.size(self.stddev)+1):
             inputs = np.hstack([self.stddev[:maxpk], self.means[:maxpk], self.amplitudes[:maxpk]])
-            new_result = optimize.minimize(self.fun_min_multiple,inputs, tol=realtol, method='Nelder-Mead')
+            new_result = optimize.minimize(self.fun_min_multiple, inputs, tol=realtol, method='Nelder-Mead')
             #If the extra peak does not substantially improve the fit, stop.
             if new_result.fun > result.fun*signif:
                 total = maxpk-1
                 break
-            else:
-                total = maxpk
-                result = new_result
             #If it did improve the fit, but didn't converge, stop anyway.
             if not new_result.success:
                 total = maxpk
                 result = new_result
                 break
+            #Otherwise, add the extra peak and continue
+            total = maxpk
+            result = new_result
         assert np.size(result.x) == total*3
         self.stddev_new = np.abs(result.x[0:total])
         self.means_new = result.x[total:2*total] % np.max(self.wavelengths)
@@ -106,14 +106,14 @@ class Profiles(object):
         #First roll the spectrum to avoid edge effects
         midpt = np.size(f)//2
         maxx = midpt - peak_index
-        f_rolled = np.roll(f,maxx)
+        f_rolled = np.roll(f, maxx)
         #Do the fit for the width
         optargs = (amplitude, f_rolled)
-        result = optimize.minimize_scalar(self.fun_min,bracket=(10.,100.),bounds=(1.,100.),method='bounded',args=optargs)
+        result = optimize.minimize_scalar(self.fun_min, bracket=(10., 100.), bounds=(1., 100.), method='bounded', args=optargs)
         #The documentation says this is how you test success, but I guess it lies!
         #if not result.success:
         #    raise RuntimeError(result.mesg)
-        fitted = self.profile(result.x,mean,amplitude)
+        fitted = self.profile(result.x, mean, amplitude)
         assert np.argmax(fitted) == peak_index
         newf = f-fitted
         assert np.max(newf) < np.max(f)
@@ -126,7 +126,7 @@ class Profiles(object):
         Function is assumed to be already rotated so that the max value is in the middle."""
         midpt = np.size(tau)//2
         assert tau[midpt] == amplitude
-        gauss = self.profile(stddev,midpt*self.dvbin, amplitude)
+        gauss = self.profile(stddev, midpt*self.dvbin, amplitude)
         assert np.argmax(gauss) == midpt
         #Try to avoid separated peaks messing with the fit.
         #We find a minima between the peak and each edge, and exclude points beyond it from the fit.
@@ -135,9 +135,9 @@ class Profiles(object):
         #Check whether the edges are a minima.
         #This is more obvious to read than mucking about with %
         if tau[-1] < tau[-2] and tau[-1] < tau[0]:
-            mins = np.append(mins,-1)
+            mins = np.append(mins, -1)
         if tau[0] < tau[-1] and tau[0] < tau[1]:
-            mins = np.append(mins,0)
+            mins = np.append(mins, 0)
         assert np.size(mins) > 0
         minn = np.max(np.append(mins[np.where(mins < midpt)], 0))
         maxx = np.min(np.append(mins[np.where(mins > midpt)], np.size(tau)))
@@ -147,7 +147,7 @@ class Profiles(object):
 
     def profile_multiple(self, stddevs, means, amplitudes):
         """Function to generate a profile consisting of multiple peaks, so we can re-fit one last time."""
-        gauss = np.sum([self.profile(stddev, mean, amplitude) for (stddev, mean, amplitude) in zip(stddevs, means, amplitudes)],axis=0)
+        gauss = np.sum([self.profile(stddev, mean, amplitude) for (stddev, mean, amplitude) in zip(stddevs, means, amplitudes)], axis=0)
         return gauss
 
     def fun_min_multiple(self, inputs):
@@ -157,7 +157,7 @@ class Profiles(object):
         stddevs = inputs[0:third]
         means = inputs[third:2*third]
         amplitudes = inputs[2*third:]
-        gauss=self.profile_multiple(stddevs, means, amplitudes)
+        gauss = self.profile_multiple(stddevs, means, amplitudes)
         return np.sum((np.exp(-self.tau) - np.exp(-gauss))**2)
 
     def voigt_profile(self, stddev, mean, amplitude):
@@ -193,11 +193,11 @@ class Profiles(object):
         assert np.argmax(profile) == peak_index
         return profile
 
-    def gaussian_profile(self, stddev,mean,amplitude):
+    def gaussian_profile(self, stddev, mean, amplitude):
         """A Gaussian profile shape"""
         midpt = np.size(self.wavelengths)//2
         gauss = np.exp(-(self.wavelengths-midpt)**2/stddev**2/2)*amplitude
-        profile = np.roll(gauss,int(round(mean/self.dvbin)) - np.argmax(gauss))
+        profile = np.roll(gauss, int(round(mean/self.dvbin)) - np.argmax(gauss))
         assert np.argmax(profile) == int(round(mean/self.dvbin))
         return profile
 
@@ -213,7 +213,7 @@ class Profiles(object):
         """Helper function to return the wavelength in km/s (offset from a 0 at the start of the box) of each absorber."""
         return np.array(self.means_new)
 
-    def get_column_density(self,btherm,amp):
+    def get_column_density(self, btherm, amp):
         """Helper function to return the column density in 1/cm^-2 given an amplitude and a dispersion."""
         #Our profile is normalised to have peak value of self.amplitudes
         #The usual normalisation is integral_R voigt  dv = 1.
@@ -243,8 +243,8 @@ class Profiles(object):
         #Get maximum and minimum extent of absorbers: this starts off as just their peaks.
         maxpos = np.array(pos)
         #Move the end of the largest object back before the beginning of the spectrum.
-        maxpos[-1]-=np.max(self.wavelengths)
-        minpos = np.roll(np.array(pos),-1)
+        maxpos[-1] -= np.max(self.wavelengths)
+        minpos = np.roll(np.array(pos), -1)
         #Compute difference in position between adjacent objects
         #this should include distance between the final and initial items
         distances = minpos-maxpos
@@ -258,7 +258,7 @@ class Profiles(object):
                 pos[minn+1] = (pos[minn]+pos[minn+1]+np.max(self.wavelengths))/2. % np.max(self.wavelengths)
             else:
                 pos[minn+1] = (pos[minn]+pos[minn+1])/2.
-            colden[minn+1] +=colden[minn]
+            colden[minn+1] += colden[minn]
             colden = np.delete(colden, minn)
             pos = np.delete(pos, minn)
             maxpos = np.delete(maxpos, minn)
@@ -283,36 +283,37 @@ class _SingleProfileHelper(object):
 
     def __call__(self, tau_t):
         """Call the fit"""
-        stime = time.clock()
+        stime = time.time()
         prof = Profiles(tau_t, self.dvbin, elem=self.elem, ion=self.ion, line=self.line)
         prof.do_fit()
         n_this, _ = prof.get_systems(self.close)
-        ftime = time.clock()
+        ftime = time.time()
         if self.verbose:
-            print("Fit: systems=",np.size(n_this),np.size(prof.get_b_params()),"N=",np.max(n_this))
-            print("Fit took: ",ftime-stime," s")
+            print("Fit: systems=", np.size(n_this), np.size(prof.get_b_params()), "N=", np.max(n_this))
+            print("Fit took: ", ftime-stime, " s")
         return n_this, prof.get_b_params()
 
-def get_voigt_fit_params(taus, dvbin, elem="H",ion=1, line=1215,verbose=False, close=0.):
+def get_voigt_fit_params(taus, dvbin, elem="H", ion=1, line=1215, verbose=False, close=0.):
     """Helper function to get the Voigt parameters, N_HI and b in a single call."""
     return get_voigt_systems(taus, dvbin, elem, ion, line, verbose, close, b_param=True)
-def get_voigt_systems(taus, dvbin, elem="H",ion=1, line=1215,verbose=False, close=0., b_param=False):
+
+def get_voigt_systems(taus, dvbin, elem="H", ion=1, line=1215, verbose=False, close=0., b_param=False):
     """Helper function to get the Voigt parameters, N_HI and (optionally) b in a single call."""
-    start = time.clock()
+    start = time.time()
     #Set up multiprocessing pool: lambdas are not picklable, so not using them.
     #functools.partial not picklable on python 2.
     helper = _SingleProfileHelper(dvbin, elem, ion, line, verbose, close)
     pool = multiprocessing.Pool(None)
-    results,b_results = zip(*pool.map(helper, taus))
+    results, b_results = zip(*pool.map(helper, taus))
     n_vals = np.concatenate(results)
-    end = time.clock()
-    print("Total fit took: ",end-start," s")
+    end = time.time()
+    print("Total fit took: ", end-start, " s")
     if b_param:
         b_params = np.concatenate(b_results)
         return n_vals, b_params
     return n_vals
 
-def _opt_power_fit(inputs,lb_params, ln_vals):
+def _opt_power_fit(inputs, lb_params, ln_vals):
     """Fit log b = log b_0  + (Gamma -1 ) * ( log NHI - log NHI,0)
     for log b_0 and Gamma-1. log NHI, 0 = 13.6"""
     lb0 = inputs[0]
@@ -323,18 +324,18 @@ def _power_fit(ln, lb0, gamm1):
     """A power law fit given some parameters"""
     return lb0 + gamm1 * (ln - 13.6)
 
-def get_b_param_dist(taus, dvbin,elem="H", ion=1, line=1215,tol=0.05):
+def get_b_param_dist(taus, dvbin, elem="H", ion=1, line=1215, tol=0.05):
     """Get the power law betweeen the 'minimum' b parameter and column density,
     following Rudie 2012 and Schaye 1999."""
-    n_vals,b_params = get_voigt_systems(taus, dvbin, elem=elem,ion=ion, line=line,verbose=False, close=-1.,b_param=True)
+    n_vals, b_params = get_voigt_systems(taus, dvbin, elem=elem, ion=ion, line=line, verbose=False, close=-1., b_param=True)
     used = np.where((b_params > 8)*(b_params < 100)*(n_vals < 10**(14.5))*(n_vals > 10**(12.5)))
     ln_vals = np.log10(n_vals[used])
     lb_params = np.log10(b_params[used])
     # The fit proceeds iteratively.
-    result = np.array([np.log10(18),0.17])
+    result = np.array([np.log10(18), 0.17])
     # First fit log b = log b_0  + (Gamma -1 ) * ( log NHI - log NHI,0)
     # for Gamma -1 and b_0 with NHI,0 = 13.6.
-    newresult = optimize.minimize(_opt_power_fit,result, args=(lb_params, ln_vals), tol=1e-4)
+    newresult = optimize.minimize(_opt_power_fit, result, args=(lb_params, ln_vals), tol=1e-4)
     while np.sum((newresult/result - 1.)**2) > tol:
         result = newresult
         #Find dispersion
@@ -347,7 +348,7 @@ def get_b_param_dist(taus, dvbin,elem="H", ion=1, line=1215,tol=0.05):
         lb_params = lb_params[used]
         ln_vals = ln_vals[used]
         #Make fit
-        newresult = optimize.minimize(_opt_power_fit,result, args=(lb_params, ln_vals), tol=1e-4)
+        newresult = optimize.minimize(_opt_power_fit, result, args=(lb_params, ln_vals), tol=1e-4)
     # Now all points > 1 sigma *below* the fit are removed and the fit is made again.
     residuals = lb_params - _power_fit(ln_vals, result[0], result[1])
     sigma_fit = np.sqrt(np.var(residuals))
@@ -356,6 +357,6 @@ def get_b_param_dist(taus, dvbin,elem="H", ion=1, line=1215,tol=0.05):
     lb_params = lb_params[used]
     ln_vals = ln_vals[used]
     #Make fit
-    newresult = optimize.minimize(_opt_power_fit,result, args=(lb_params, ln_vals), tol=1e-4)
+    newresult = optimize.minimize(_opt_power_fit, result, args=(lb_params, ln_vals), tol=1e-4)
     #Return the new b_min and Gamma.
     return (10**newresult[0], newresult[1])

--- a/fake_spectra/voigtfit.py
+++ b/fake_spectra/voigtfit.py
@@ -141,6 +141,8 @@ class Profiles(object):
         if tau[0] < tau[-1] and tau[0] < tau[1]:
             mins = np.append(mins, 0)
         assert np.size(mins) > 0
+        # only use minima that are low enough compared to peak (~0.08 different in flux)
+        mins = mins[np.where(np.abs(amplitude - tau[mins]) > np.log(1./0.92))]
         minn = np.max(np.append(mins[np.where(mins < midpt)], 0))
         maxx = np.min(np.append(mins[np.where(mins > midpt)], np.size(tau)))
         assert minn < midpt and maxx > midpt

--- a/fake_spectra/voigtfit.py
+++ b/fake_spectra/voigtfit.py
@@ -112,9 +112,6 @@ class Profiles(object):
         #Do the fit for the width
         optargs = (amplitude, f_rolled)
         result = optimize.minimize_scalar(self.fun_min, bracket=(10., 120.), bounds=(1., 120.), method='bounded', args=optargs)
-        #The documentation says this is how you test success, but I guess it lies!
-        #if not result.success:
-        #    raise RuntimeError(result.mesg)
         fitted = self.profile(result.x, mean, amplitude)
         assert np.argmax(fitted) == peak_index
         newf = f-fitted
@@ -337,7 +334,7 @@ def get_b_param_dist(taus, dvbin, elem="H", ion=1, line=1215):
     sort = np.argsort(np.log10(n_vals[used]))
     ln_vals = np.log10(n_vals[used])[sort]
     lb_params = np.log10(b_params[used])[sort]
-    
+
     ###################### sigma rejection ###########################
     # will add each bin to final_retained as we iterate through
     # this works because the values are sorted
@@ -358,13 +355,13 @@ def get_b_param_dist(taus, dvbin, elem="H", ion=1, line=1215):
             bin_range = bin_range*keep
 
         # switch previously omitted points which are above the mean to true, including points over 40
-        bin_range[(bin_range == False)*(lb_params > mean)] = True
-        final_retained = np.append(final_retained, bin_range[bin_edges[0][0]:bin_edges[0][-1]+1])  
+        bin_range[(bin_range is False)*(lb_params > mean)] = True
+        final_retained = np.append(final_retained, bin_range[bin_edges[0][0]:bin_edges[0][-1]+1])
 
     ln_vals = ln_vals[final_retained]
     lb_params = lb_params[final_retained]
     #################################################################
-    
+
     # The fit proceeds iteratively.
     result = np.array([np.log10(18), 0.17])
     # First fit log b = log b_0 + (Gamma -1) * (log NHI - log NHI,0)

--- a/fake_spectra/voigtfit.py
+++ b/fake_spectra/voigtfit.py
@@ -290,7 +290,7 @@ class _SingleProfileHelper(object):
         """Call the fit"""
         stime = time.time()
         prof = Profiles(tau_t, self.dvbin, elem=self.elem, ion=self.ion, line=self.line)
-        prof.do_fit()
+        prof.do_fit(tol=1e-4, signif=0.95, sattau=4)
         n_this, _ = prof.get_systems(self.close)
         ftime = time.time()
         if self.verbose:

--- a/fake_spectra/voigtfit.py
+++ b/fake_spectra/voigtfit.py
@@ -243,6 +243,7 @@ class Profiles(object):
         pos = self.get_positions()
         sorter = np.argsort(pos)
         colden = self.get_column_densities()[sorter]
+        self.stddev_new = self.stddev_new[sorter]
         pos = pos[sorter]
         #Get maximum and minimum extent of absorbers: this starts off as just their peaks.
         maxpos = np.array(pos)


### PR DESCRIPTION
The primary changes to the Voigt fitting code are:

- increasing the fit tolerance for the combined spectrum (so it continues so long as the fit is reasonable)
- adjusting the significance check for adding another peak to the combined fit so that it will include smaller peaks
- increasing the upper bound on the Voigt width when fitting individual peaks (allows for broader peaks)
- extending the mask for the individual Voigt fitting, so that local minima which are not very different from the peak are not used -- this helps reduce overfitting
- fixing the sorting mismatch by sorting the widths in addition to the column densities

The primary changes to the cutoff fitting code are mostly adjustments to make the algorithm agree more closely with Schaye 1999 and Rudie 2012:

- include the sigma-rejection step used in Rudie 2012 (eliminates most points which end up below the cutoff and are likely blended lines)
- change from RMS to mean absolute deviation
- change convergence from tolerance based to completion (i.e. go until no more points are removed)