### PR TITLE
Chaning the resoluton when reloading the saved spectra

### DIFF
--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -191,8 +191,12 @@ class Spectra:
         self.vmax = self.box * self.velfac # box size (physical kms^-1)
         self.NumLos = np.size(self.axis)
         try:
-            # velocity bin size (kms^-1)
-            self.dvbin = self.vmax / (1.*self.nbins)
+            # Check if desired pixel size matches with self.nbins
+            if np.around(self.vmax/res) != self.nbins :
+                raise AttributeError:
+            else:
+                # velocity bin size (kms^-1)
+                self.dvbin = self.vmax / (1.*self.nbins)
         except AttributeError:
             #This will occur if we are not loading from a savefile
             self.dvbin = res # velocity bin size (kms^-1)

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -193,7 +193,7 @@ class Spectra:
         try:
             # Check if desired pixel size matches with self.nbins
             if np.around(self.vmax/res) != self.nbins :
-                raise AttributeError:
+                raise AttributeError
             else:
                 # velocity bin size (kms^-1)
                 self.dvbin = self.vmax / (1.*self.nbins)


### PR DESCRIPTION
In case we want to change the pixel resolution after loading the saved spectra files, ```self.nbins``` has already been recorded on those (with the previous resolution ), and therefore will not raise any ```AtributeError``` by itself. We should check whether it matches with the new resolution.