### PR TITLE
Axis in grid

### DIFF
--- a/fake_spectra/griddedspectra.py
+++ b/fake_spectra/griddedspectra.py
@@ -7,25 +7,49 @@ from . import abstractsnapshot as absn
 from . import spectra
 
 class GriddedSpectra(spectra.Spectra):
-    """Generate metal line spectra from simulation snapshot. Default parameters are BOSS DR9"""
-    def __init__(self,num, base, nspec=200, res = 90., savefile="gridded_spectra.hdf5", reload_file=True, **kwargs):
+    """Generate regular grid of spectra along a given axis."""
+
+    def __init__(self,num, base, nspec=200, res = 90., 
+            savefile="gridded_spectra.hdf5", reload_file=True,
+            axis=1, **kwargs):
+
+        print('------- PRINT KWARGS -------')
+        for key, value in kwargs.items():
+            print("{0} = {1}".format(key, value))
+        print('------- END KWARGS -------')
+
         # get box size from file (either HDF5 or BigFile)
         f = absn.AbstractSnapshotFactory(num, base)
         self.box = f.get_header_attr("BoxSize")
         del f
-        self.NumLos = nspec*nspec
-        #All through y axis
-        axis = np.ones(self.NumLos)
-        # get position of skewers (on a regular grid)
-        cofm = self.get_cofm()
-        spectra.Spectra.__init__(self,num, base, cofm=cofm, axis=axis, res=res, savefile=savefile, reload_file=reload_file, **kwargs)
+        # get position of skewers in the grid
+        grid_axes, grid_cofm = self.get_axes_and_cofm(nspec,axis)
+        # call constructor of base class
+        spectra.Spectra.__init__(self,num,base,cofm=grid_cofm,axis=grid_axes,
+                res=res,savefile=savefile,reload_file=reload_file,**kwargs)
 
-    def get_cofm(self, num = None):
-        """Find a bunch more sightlines: should be overriden by child classes"""
-        if num is None:
-            num = int(np.sqrt(self.NumLos))
-        cofm = np.empty([num*num, 3])
-        for nn in range(num):
-            for mm in range(num):
-                cofm[nn*num+mm] = self.box*np.array([nn, nn, mm])/(1.*num)
-        return cofm
+
+    def get_axes_and_cofm(self,nspec,axis):
+        """Define position of skewers in the grid"""
+
+        # decide axis to use to extract skewers (x axis by default)
+        grid_axes = axis*np.ones(nspec*nspec)
+
+        # separation between skewes in the grid (per side)
+        dx=self.box/(1.*nspec)
+        # allocate memory for all 3D positions
+        grid_cofm = np.empty([nspec*nspec, 3])
+        for nn in range(nspec):
+            for mm in range(nspec):
+                ii=nn*nspec+mm
+                # define grid positions depending on axis
+                if axis==1:
+                    grid_cofm[ii] = np.array([0, nn, mm]) * dx
+                elif axis==2:
+                    grid_cofm[ii] = np.array([nn, 0, mm]) * dx
+                elif axis==3:
+                    grid_cofm[ii] = np.array([nn, mm, 0]) * dx
+                else:
+                    raise ValueError('wrong axis number {}'.format(axis))
+
+        return grid_axes, grid_cofm

--- a/fake_spectra/griddedspectra.py
+++ b/fake_spectra/griddedspectra.py
@@ -30,21 +30,17 @@ class GriddedSpectra(spectra.Spectra):
         # decide axis to use to extract skewers (x axis by default)
         grid_axes = axis*np.ones(nspec*nspec)
 
-        # separation between skewes in the grid (per side)
-        dx=self.box/(1.*nspec)
-        # allocate memory for all 3D positions
-        grid_cofm = np.empty([nspec*nspec, 3])
-        for nn in range(nspec):
-            for mm in range(nspec):
-                ii=nn*nspec+mm
-                # define grid positions depending on axis
-                if axis==1:
-                    grid_cofm[ii] = np.array([0, nn, mm]) * dx
-                elif axis==2:
-                    grid_cofm[ii] = np.array([nn, 0, mm]) * dx
-                elif axis==3:
-                    grid_cofm[ii] = np.array([nn, mm, 0]) * dx
-                else:
-                    raise ValueError('wrong axis number {}'.format(axis))
+        # figure out grid of positions for this particular axis
+        if axis==1:
+            grid_id=[np.array([0,nn,mm]) for nn in range(nspec) for mm in range(nspec)]
+        elif axis==2:
+            grid_id=[np.array([nn,0,mm]) for nn in range(nspec) for mm in range(nspec)]
+        elif axis==3:
+            grid_id=[np.array([nn,mm,0]) for nn in range(nspec) for mm in range(nspec)]
+        else:
+            raise ValueError('wrong axis number {}'.format(axis))
 
-        return grid_axes, grid_cofm
+        # separation between skewers in the grid (per side)
+        dx=self.box/(1.*nspec)
+
+        return grid_axes, dx*np.array(grid_id)

--- a/fake_spectra/griddedspectra.py
+++ b/fake_spectra/griddedspectra.py
@@ -13,11 +13,6 @@ class GriddedSpectra(spectra.Spectra):
             savefile="gridded_spectra.hdf5", reload_file=True,
             axis=1, **kwargs):
 
-        print('------- PRINT KWARGS -------')
-        for key, value in kwargs.items():
-            print("{0} = {1}".format(key, value))
-        print('------- END KWARGS -------')
-
         # get box size from file (either HDF5 or BigFile)
         f = absn.AbstractSnapshotFactory(num, base)
         self.box = f.get_header_attr("BoxSize")


### PR DESCRIPTION
Added option to set axis when creating a GriddedSpectra object. 

Note also that I have removed get_cofm function, since it doesn't make sense to call Spectra.replace_not_DLA when working with spectra in a grid.  I could add it back and raise a ValueError if anyone tries to use it.