### PR TITLE
Fix dvbin

### DIFF
--- a/fake_spectra/griddedspectra.py
+++ b/fake_spectra/griddedspectra.py
@@ -9,7 +9,7 @@ from . import spectra
 class GriddedSpectra(spectra.Spectra):
     """Generate regular grid of spectra along a given axis."""
 
-    def __init__(self,num, base, nspec=200, res = 90., 
+    def __init__(self,num, base, nspec=200, res = None,
             savefile="gridded_spectra.hdf5", reload_file=True,
             axis=1, **kwargs):
 

--- a/fake_spectra/halospectra.py
+++ b/fake_spectra/halospectra.py
@@ -16,7 +16,7 @@ except NameError:
 
 class HaloSpectra(spectra.Spectra):
     """Generate spectra from simulation snapshot which are near to galactic halos."""
-    def __init__(self,num, base, repeat = 1, min_mass = 1e9, max_mass=1e11, res = 1., offset=1., savefile="halo_spectra.hdf5", savedir=None, cdir=None):
+    def __init__(self,num, base, repeat = 1, min_mass = 1e9, max_mass=1e11, res = None, offset=1., savefile="halo_spectra.hdf5", savedir=None, cdir=None):
         if savedir is None:
             savedir = path.join(base,"snapdir_"+str(num).rjust(3,'0'))
         self.savefile = path.join(savedir,savefile)

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -80,7 +80,7 @@ class Spectra:
                      kernel (a good back up for large Arepo simulations) "quintic" for a quintic SPh kernel as used in modern SPH
                      and "cubic" or "sph" for an old-school cubic SPH kernel.
     """
-    def __init__(self,num, base,cofm, axis, res=1., cdir=None, savefile="spectra.hdf5", savedir=None, reload_file=False, spec_res = 0,load_halo=False, units=None, sf_neutral=True,quiet=False, load_snapshot=True, gasprop=None, gasprop_args=None, kernel=None):
+    def __init__(self,num, base,cofm, axis, res=None, cdir=None, savefile="spectra.hdf5", savedir=None, reload_file=False, spec_res = 0,load_halo=False, units=None, sf_neutral=True,quiet=False, load_snapshot=True, gasprop=None, gasprop_args=None, kernel=None):
         #Present for compatibility. Functionality moved to HaloAssignedSpectra
         _= load_halo
         self.num = num
@@ -190,18 +190,19 @@ class Spectra:
         self.NumLos = np.size(self.axis)
         # specify pixel width and number of pixels in spectra
         if reload_file:
-            # nbins must be an integer (could consider making it an even number)
-            #self.nbins=2*int(0.5*self.vmax/res)
+            # if reloading from snapshot, pixel width must have been defined
+            if res is None:
+                raise ValueError('pixel width (res) not provided')
+            # nbins must be an integer
             self.nbins=int(self.vmax/res)
             # velocity bin size (kms^-1)
             self.dvbin = self.vmax / (1.*self.nbins)
         else:
             # self.nbins already set from file
             self.dvbin = self.vmax / (1.*self.nbins)
-            # check if you asked for different pixel width (could drop this)
-            if not np.isclose(self.dvbin,res,rtol=1e-4):
-                print('WARNING: pixel width read = {} km/s'.format(self.dvbin))
-                print('does not match value asked = {} km/s'.format(res))
+            # check if you asked for different pixel width
+            if res is not None:
+                assert np.isclose(self.dvbin,res,rtol=1e-4),'pixel width error'
         #Species we can use: Z is total metallicity
         self.species = ['H', 'He', 'C', 'N', 'O', 'Ne', 'Mg', 'Si', 'Fe', 'Z']
         #Solar abundances from Asplund 2009 / Grevasse 2010 (which is used in Cloudy 13, Hazy Table 7.4).

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -188,18 +188,20 @@ class Spectra:
         self.velfac = self.rscale * Hz / 3.085678e24
         self.vmax = self.box * self.velfac # box size (physical kms^-1)
         self.NumLos = np.size(self.axis)
-        try:
-            # Check if desired pixel size matches with self.nbins
-            if np.around(self.vmax/res) != self.nbins :
-                raise AttributeError
-            else:
-                # velocity bin size (kms^-1)
-                self.dvbin = self.vmax / (1.*self.nbins)
-        except AttributeError:
-            #This will occur if we are not loading from a savefile
-            self.dvbin = res # velocity bin size (kms^-1)
-            #Number of bins to achieve the required resolution
-            self.nbins = int(self.vmax / self.dvbin)
+        # specify pixel width and number of pixels in spectra
+        if reload_file:
+            # nbins must be an integer (could consider making it an even number)
+            #self.nbins=2*int(0.5*self.vmax/res)
+            self.nbins=int(self.vmax/res)
+            # velocity bin size (kms^-1)
+            self.dvbin = self.vmax / (1.*self.nbins)
+        else:
+            # self.nbins already set from file
+            self.dvbin = self.vmax / (1.*self.nbins)
+            # check if you asked for different pixel width (could drop this)
+            if not np.isclose(self.dvbin,res,rtol=1e-4):
+                print('WARNING: pixel width read = {} km/s'.format(self.dvbin))
+                print('does not match value asked = {} km/s'.format(res))
         #Species we can use: Z is total metallicity
         self.species = ['H', 'He', 'C', 'N', 'O', 'Ne', 'Mg', 'Si', 'Fe', 'Z']
         #Solar abundances from Asplund 2009 / Grevasse 2010 (which is used in Cloudy 13, Hazy Table 7.4).


### PR DESCRIPTION
Addresses issue #47 , by changing the way we set self.nbins and self.dvbin in Spectra class.

To be decided: 
 - Because of possible FFTs and similar, should we force self.nbins to be an even integer? I'm guessing maybe not, if you care about this you can choose the pixel width carefully yourself?
 - How noisy should we be if someone asks for a particular pixel width, but load spectra from savefile that has a different pixel width? The problem is that the option "res" is by default set to 1 (not None), so it is not easy to do the test, otherwise I'd make the code crash if there is a mismatch. For now I just print a warning message, and carry on with the code ignoring "res".