### PR TITLE
removing spec_res convolution from get_tau

### DIFF
--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -836,16 +836,6 @@ class Spectra:
             self.tau[(elem, ion, line)] = tau
         if number >= 0:
             tau = tau[number, :]
-        #Correct for the spectrograph resolution in flux space.
-        #We need to cap the optical depth to avoid divide-by-zero
-        if self.spec_res > 0:
-            tau[np.where(tau > 700)] = 700
-            corrflux = spec_utils.res_corr(np.exp(-tau), self.dvbin, self.spec_res)
-            flux = corrflux
-            if np.any(corrflux <= 0):
-                raise Exception
-            tau = - np.log(corrflux) 
-
         return tau
 
 


### PR DESCRIPTION
Converting tau to flux and then back to tau is not stable. We get 0 in the `log()` for extended absorbers. If any one is interested in convolving the spectra with spectra resolution, they can call `spec_utils.res_corr()` which works only with flux.