### PR TITLE
no need to open snapshot when reading gridded spectra from files

### DIFF
--- a/fake_spectra/griddedspectra.py
+++ b/fake_spectra/griddedspectra.py
@@ -26,9 +26,8 @@ class GriddedSpectra(spectra.Spectra):
             grid_axes, grid_cofm = self.get_axes_and_cofm(nspec,axis)
 
         # call constructor of base class
-        spectra.Spectra.__init__(self,num,base,cofm=grid_cofm,axis=grid_axes,
-                MPI=MPI,res=res,savefile=savefile,reload_file=reload_file,
-                **kwargs)
+        spectra.Spectra.__init__(self,num,base,cofm=grid_cofm,axis=grid_axes,MPI=MPI,
+                res=res,savefile=savefile,reload_file=reload_file,**kwargs)
 
 
     def get_axes_and_cofm(self,nspec,axis):

--- a/fake_spectra/griddedspectra.py
+++ b/fake_spectra/griddedspectra.py
@@ -13,15 +13,22 @@ class GriddedSpectra(spectra.Spectra):
             savefile="gridded_spectra.hdf5", reload_file=True,
             axis=1, **kwargs):
 
-        # get box size from file (either HDF5 or BigFile)
-        f = absn.AbstractSnapshotFactory(num, base)
-        self.box = f.get_header_attr("BoxSize")
-        del f
-        # get position of skewers in the grid
-        grid_axes, grid_cofm = self.get_axes_and_cofm(nspec,axis)
+        if reload_file==False:
+            # if reading skewers from file, no need to read the snapshot
+            grid_cofm=None
+            grid_axes=None
+        else:
+            # get box size from file (either HDF5 or BigFile)
+            f = absn.AbstractSnapshotFactory(num, base)
+            self.box = f.get_header_attr("BoxSize")
+            del f
+            # get position of skewers in the grid
+            grid_axes, grid_cofm = self.get_axes_and_cofm(nspec,axis)
+
         # call constructor of base class
-        spectra.Spectra.__init__(self,num,base,cofm=grid_cofm,axis=grid_axes,MPI=MPI,
-                res=res,savefile=savefile,reload_file=reload_file,**kwargs)
+        spectra.Spectra.__init__(self,num,base,cofm=grid_cofm,axis=grid_axes,
+                MPI=MPI,res=res,savefile=savefile,reload_file=reload_file,
+                **kwargs)
 
 
     def get_axes_and_cofm(self,nspec,axis):


### PR DESCRIPTION
Until now GriddedSpectra always needed access to the snapshot even when reading pre-computed spectra from file, since it neeed its BoxSize to compute the grid positions of the lines of sight. 

However, this information is already contained in written files, so no need to compute these when reading from file. This is important since often the snapshots are very large and might not be available at the time of reading (I store them on tape).

This functionality was already present in Spectra, it is only GriddedSpectra that needs this small update.