### PR TITLE
added option to specify value of H(z) to use

### DIFF
--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -78,10 +78,13 @@ class Spectra:
                      Other options are "voronoi" which forces the Voronoi kernel, "tophat" which forces a flat tophat
                      kernel (a good back up for large Arepo simulations) "quintic" for a quintic SPh kernel as used in modern SPH
                      and "cubic" or "sph" for an old-school cubic SPH kernel.
+            use_external_Hz - user provided value for H(z) [km/s/Mpc] to be used
+                     when converting comoving to velocity units.
+                     If not proviced, will assume flat LCDM and compute it.
     """
     def __init__(self, num, base, cofm, axis, MPI=None, res=1., cdir=None, savefile="spectra.hdf5",
                  savedir=None, reload_file=False, spec_res = 0,load_halo=False, units=None, sf_neutral=True,
-                 quiet=False, load_snapshot=True, gasprop=None, gasprop_args=None, kernel=None):
+                 quiet=False, load_snapshot=True, gasprop=None, gasprop_args=None, kernel=None, use_external_Hz=None):
 
         #Present for compatibility. Functionality moved to HaloAssignedSpectra
         _= load_halo
@@ -156,6 +159,7 @@ class Spectra:
             if not path.exists(savedir):
                 savedir = path.join(base, "SPECTRA_"+str(num).rjust(3, '0'))
         self.savefile = path.join(savedir, savefile)
+
         #Snapshot data
         if reload_file:
             if not quiet:
@@ -188,16 +192,27 @@ class Spectra:
             except KeyError:
                 if not quiet:
                     print('No units found. Using kpc/kms/10^10Msun by default')
+            #user defined Hubble parameter at the relevant redshift [km/s/Mpc]
+            if use_external_Hz:
+                self.Hz=use_external_Hz
+                if not quiet:
+                    print('Use external value of H(z)=',self.Hz)
+            else:
+                #if not specified, H(z) will be computed later
+                self.Hz=None
         else:
+            if not quiet:
+                print("Reading pre-computed spectra (from file", self.savefile, " )", flush=True)
             self.load_savefile(self.savefile)
+
         # Conversion factors from internal units
         self.rscale = (self.units.UnitLength_in_cm*self.atime)/self.hubble
-        # Convert length to physical cm
-        # Calculate the length scales to be used in the box: Hz in km/s/Mpc
-        Hz = 100.0*self.hubble * np.sqrt(self.OmegaM/self.atime**3 + self.OmegaLambda)
         #Convert comoving internal units to physical km/s.
+        if self.Hz is None:
+            #Assume flat LCDM cosmology to compute H(z) (in km/s/Mpc)
+            self.Hz = 100.0*self.hubble * np.sqrt(self.OmegaM/self.atime**3 + self.OmegaLambda)
         #Numerical constant is 1 Mpc in cm.
-        self.velfac = self.rscale * Hz / 3.085678e24
+        self.velfac = self.rscale * self.Hz / 3.085678e24
         self.vmax = self.box * self.velfac # box size (physical kms^-1)
         self.NumLos = np.size(self.axis)
         # specify pixel width and number of pixels in spectra
@@ -278,6 +293,7 @@ class Spectra:
         grp.attrs["omegal"] = self.OmegaLambda
         grp.attrs["discarded"] = self.discarded
         grp.attrs["npart"] = self.npart
+        grp.attrs["Hz"] = self.Hz
         grp = f.create_group("spectra")
         grp["cofm"] = self.cofm
         grp["axis"] = self.axis
@@ -464,6 +480,11 @@ class Spectra:
         grp = f["spectra"]
         self.cofm = np.array(grp["cofm"])
         self.axis = np.array(grp["axis"])
+        # older files might not have Hz stored
+        if "Hz" in grid_file.attrs:
+            self.Hz = grid_file.attrs["Hz"]
+        else:
+            self.Hz = None
         f.close()
 
     def _interpolate_single_file(self, nsegment, elem, ion, ll, get_tau, load_all_data_first=False):

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -230,6 +230,9 @@ class Spectra:
             # check if you asked for different pixel width
             if res is not None:
                 assert np.isclose(self.dvbin,res,rtol=1e-2),'pixel width error'
+            # check if you asked for different H(z) than the one in the file
+            if use_external_Hz:
+                assert np.isclose(self.Hz,use_external_Hz,rtol=1e-4),'Hz error'
         #Species we can use: Z is total metallicity
         self.species = ['H', 'He', 'C', 'N', 'O', 'Ne', 'Mg', 'Si', 'Fe', 'Z']
         #Solar abundances from Asplund 2009 / Grevasse 2010 (which is used in Cloudy 13, Hazy Table 7.4).


### PR DESCRIPTION
This small PR addresses issue #57 , by adding an option to specify the value of H(z) to be used when extracting the flux. 

For consistency, this value is now also stored in the spectra files, and it is read when reading pre-computed spectra.

These are the possible working modes:
A) when extracting skewers from snapshot
  A.1) if use_external_Hz is *not* provided it will compute it in flat LCDM
  A.2) if use_external_Hz is provided it will use this value
B) when reading old skewers from file (that did not have Hz stored, and assumed flat LCDM)
  B.1) if use_external_Hz is *not* provided it will compute it in flat LCDM
  B.2) if use_external_Hz is provided it will check that it agrees with the one computed in flat LCDM
C) when reading new skewers from file (that have Hz stored)
  C.1) if use_external_Hz is *not* provided it will use the value of Hz read from file
  C.2) if use_external_Hz is provided it will check that it agrees with the one read from file

I checked that indeed this is what happens by running some tests on my laptop.