### PR TITLE
Simple rtn from Schmidt+2019

### DIFF
--- a/fake_spectra/rate_network.py
+++ b/fake_spectra/rate_network.py
@@ -190,12 +190,13 @@ class RateNetwork(object):
 
     def _nHep(self, nh, temp, nebynh):
         """The ionised helium number density, divided by the helium number fraction. Eq. 35 of KWH."""
-        alphaHep = self.recomb.alphaHep(temp) + self.recomb.alphad(temp)
-        alphaHepp = self.recomb.alphaHepp(temp)
-        photofac = self._photofac(nebynh, nh, temp)
-        GammaHe0 = self.collisional * self.recomb.GammaeHe0(temp) + self.photo.gHe0(self.redshift)*photofac
-        GammaHep = self.collisional * self.recomb.GammaeHep(temp) + self.photo.gHep(self.redshift)*photofac
-        return 1. / (1 + alphaHep / GammaHe0 + GammaHep/alphaHepp)
+        #alphaHep = self.recomb.alphaHep(temp) + self.recomb.alphad(temp)
+        #alphaHepp = self.recomb.alphaHepp(temp)
+        #photofac = self._photofac(nebynh, nh, temp)
+        #GammaHe0 = self.collisional * self.recomb.GammaeHe0(temp) + self.photo.gHe0(self.redshift)*photofac
+        #GammaHep = self.collisional * self.recomb.GammaeHep(temp) + self.photo.gHep(self.redshift)*photofac
+        #return 1. / (1 + alphaHep / GammaHe0 + GammaHep/alphaHepp)
+        return self._nHp(nh,temp,nebynh)
 
     def _nHe0(self, nh, temp, nebynh):
         """The neutral helium number density, divided by the helium number fraction. Eq. 36 of KWH."""
@@ -206,10 +207,11 @@ class RateNetwork(object):
 
     def _nHepp(self, nh, temp, nebynh):
         """The doubly ionised helium number density, divided by the helium number fraction. Eq. 37 of KWH."""
-        photofac = self._photofac(nebynh, nh, temp)
-        GammaHep = self.collisional * self.recomb.GammaeHep(temp) + self.photo.gHep(self.redshift)*photofac
-        alphaHepp = self.recomb.alphaHepp(temp)
-        return self._nHep(nh, temp, nebynh) * GammaHep / alphaHepp
+        #photofac = self._photofac(nebynh, nh, temp)
+        #GammaHep = self.collisional * self.recomb.GammaeHep(temp) + self.photo.gHep(self.redshift)*photofac
+        #alphaHepp = self.recomb.alphaHepp(temp)
+        #return self._nHep(nh, temp, nebynh) * GammaHep / alphaHepp
+        return np.zeros_like(nh)
 
     def _nebynh(self, nh, temp, nebynh, helium=0.24):
         """The electron number density per hydrogen atom. Eq. 38 of KWH."""

--- a/fake_spectra/ratenetworkspectra.py
+++ b/fake_spectra/ratenetworkspectra.py
@@ -38,7 +38,12 @@ class RateNetworkGas(gas_properties.GasProperties):
         """Compute temperature (in K) from internal energy using the rate network."""
         temp, ii2, density, ienergy = self._get_interp(part_type, segment, nhi=False)
         if np.size(ii2) > 0:
-            temp[ii2] = self.rates.get_temp(density[ii2], ienergy[ii2])
+            if self.sf_neutral:
+                #temp[ii2] = self.rates._get_temp(np.zeros_like(ii2), ienergy[ii2])
+                #print('temp[ii2], max and min', np.max(temp[ii2]), np.min(temp[ii2]), flush=True)
+                temp[ii2] = 1e4*np.ones_like(ii2)
+            else:
+                temp[ii2] = self.rates.get_temp(density[ii2], ienergy[ii2])
         assert np.all(np.logical_not(np.isnan(temp)))
         return temp
 


### PR DESCRIPTION
- Assuming nHeII/nHe = nHII/nH and nHeIII=0
- It effects ne calculations

Looking at the difference on 10 random spectra with pixel resolution of `10 km/s` in TNG300-1, we find the difference to be marginal, it is `\Delta F <= 0.05` around pixels with `F ~ 0`. This difference is much smaller than the one between Hydro and FGPA, so It cannot explain the discrepancy between our results and Kooistra+2022

Should we start getting suspicious about the pixelization of the density and velocity in their work ?


![Full_vs_simple_rtn_highres](https://user-images.githubusercontent.com/44325095/155589229-9e4cc9b6-d5f2-4235-8a08-10b76ccc1fc0.png)

