### PR TITLE
`macos` wheels on pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -100,5 +100,5 @@ jobs:
       - name: Install the pushed package
         run: |
           python -m pip install --upgrade pip
-          pip install -i https://test.pypi.org/simple/ testmacfk
+          pip install fake_spectra
 


### PR DESCRIPTION
I have tested this on `test pypi` and works well. It simultaneously publishes a source distribution for linux and a wheel for macos.  