### PR TITLE
Fixing the interpolation scheme for 3D power

### DIFF
--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -1307,7 +1307,7 @@ class Spectra:
         tau = self.get_tau(elem, ion, line)
         #Remove sightlines which contain a strong absorber
         tau = self._filter_tau(tau, tau_thresh=tau_thresh)
-        (k, mu, avg_flux_power) = fstat.flux_power_3d(comm_nbodykit, tau, self.box, mean_flux_desired, dk=dk, Nmu=Nmu)
+        (k, mu, avg_flux_power) = fstat.flux_power_3d(comm_nbodykit, tau, self.box, mean_flux_desired, dk=dk, Nmu=Nmu, quiet=False)
         # The fist row is the k=0, which we ommit
         return k[1:,:], mu[1:,:], avg_flux_power[1:,:]
 


### PR DESCRIPTION
- If the spectra is not on a unifrm grid, calculates the average `delta_F` on a unifrom grid with the same resolution as the transverse direction
- The power for a grid with the resoltion of (250, 250, 105) ckpc/h will be 5-10% different from a unifrom grid of (105, 105, 105) ckp/h.
- So it would be ideal if someone uses a higher resolution unifrom map from the begining