### PR TITLE
get_tau: TypeError: One of the data arrays does not have 32-bit float type

### DIFF
--- a/fake_spectra/ratenetworkspectra.py
+++ b/fake_spectra/ratenetworkspectra.py
@@ -57,7 +57,7 @@ class RateNetworkGas(gas_properties.GasProperties):
         density = self.get_code_rhoH(part_type, segment)
         #expecting units of 10^-10 ergs/g
         ienergy = self.absnap.get_data(part_type, "InternalEnergy", segment=segment)*self.units.UnitInternalEnergy_in_cgs/1e10
-        ienergy = np.float32(self._get_ienergy_rescaled(density, ienergy))
+        ienergy = self._get_ienergy_rescaled(density, ienergy)
         ldensity = np.log(density)
         lienergy = np.log(ienergy)
         #Clamp the temperatures : hot gas has the same neutral fraction of 0 anyway.
@@ -76,7 +76,12 @@ class RateNetworkGas(gas_properties.GasProperties):
             zgrid = self.lh0grid
         else:
             zgrid = self.tempgrid
-        out[ii] = np.exp(_interpolate_2d(ldensity[ii], lienergy[ii], self.densgrid, self.ienergygrid, zgrid))
+
+        # cast ONLY the vectors you pass into the C-extension
+        x32 = np.ascontiguousarray(ldensity[ii], dtype=np.float32)
+        y32 = np.ascontiguousarray(lienergy[ii], dtype=np.float32)
+
+        out[ii] = np.exp(_interpolate_2d(x32, y32, self.densgrid, self.ienergygrid, zgrid))
         ii2 = np.where(ldensity >= np.max(self.densgrid))
         return out,ii2,density,ienergy
 

--- a/fake_spectra/ratenetworkspectra.py
+++ b/fake_spectra/ratenetworkspectra.py
@@ -30,11 +30,11 @@ class RateNetworkGas(gas_properties.GasProperties):
     def build_interp(self, dlim, elim, tsz=500, dsz=1000):
         """Build the interpolator"""
         #Build interpolation
-        self.densgrid = np.linspace(dlim[0], dlim[1], dsz)
-        self.ienergygrid = np.linspace(elim[0], elim[1], tsz)
+        self.densgrid = np.linspace(dlim[0], dlim[1], dsz, dtype=np.float32)
+        self.ienergygrid = np.linspace(elim[0], elim[1], tsz, dtype=np.float32)
         dgrid, egrid = np.meshgrid(self.densgrid, self.ienergygrid)
-        self.lh0grid = np.zeros_like(dgrid)
-        self.tempgrid = np.zeros_like(dgrid)
+        self.lh0grid = np.zeros_like(dgrid, dtype=np.float32)
+        self.tempgrid = np.zeros_like(dgrid, dtype=np.float32)
         #We assume primordial helium
         for i in range(dsz):
             self.lh0grid[:,i] = np.log(self.rates.get_neutral_fraction(np.exp(dgrid[:,i]), np.exp(egrid[:,i])))
@@ -57,7 +57,7 @@ class RateNetworkGas(gas_properties.GasProperties):
         density = self.get_code_rhoH(part_type, segment)
         #expecting units of 10^-10 ergs/g
         ienergy = self.absnap.get_data(part_type, "InternalEnergy", segment=segment)*self.units.UnitInternalEnergy_in_cgs/1e10
-        ienergy = self._get_ienergy_rescaled(density, ienergy)
+        ienergy = np.float32(self._get_ienergy_rescaled(density, ienergy))
         ldensity = np.log(density)
         lienergy = np.log(ienergy)
         #Clamp the temperatures : hot gas has the same neutral fraction of 0 anyway.

--- a/fake_spectra/ratenetworkspectra.py
+++ b/fake_spectra/ratenetworkspectra.py
@@ -30,11 +30,11 @@ class RateNetworkGas(gas_properties.GasProperties):
     def build_interp(self, dlim, elim, tsz=500, dsz=1000):
         """Build the interpolator"""
         #Build interpolation
-        self.densgrid = np.linspace(dlim[0], dlim[1], dsz, dtype=np.float32)
-        self.ienergygrid = np.linspace(elim[0], elim[1], tsz, dtype=np.float32)
+        self.densgrid = np.linspace(dlim[0], dlim[1], dsz)
+        self.ienergygrid = np.linspace(elim[0], elim[1], tsz)
         dgrid, egrid = np.meshgrid(self.densgrid, self.ienergygrid)
-        self.lh0grid = np.zeros_like(dgrid, dtype=np.float32)
-        self.tempgrid = np.zeros_like(dgrid, dtype=np.float32)
+        self.lh0grid = np.zeros_like(dgrid)
+        self.tempgrid = np.zeros_like(dgrid)
         #We assume primordial helium
         for i in range(dsz):
             self.lh0grid[:,i] = np.log(self.rates.get_neutral_fraction(np.exp(dgrid[:,i]), np.exp(egrid[:,i])))
@@ -58,8 +58,8 @@ class RateNetworkGas(gas_properties.GasProperties):
         #expecting units of 10^-10 ergs/g
         ienergy = self.absnap.get_data(part_type, "InternalEnergy", segment=segment)*self.units.UnitInternalEnergy_in_cgs/1e10
         ienergy = self._get_ienergy_rescaled(density, ienergy)
-        ldensity = np.log(density)
-        lienergy = np.log(ienergy)
+        ldensity = np.log(density).astype(np.float32, copy=False)
+        lienergy = np.log(ienergy).astype(np.float32, copy=False)
         #Clamp the temperatures : hot gas has the same neutral fraction of 0 anyway.
         ie = np.where(lienergy >= np.max(self.ienergygrid))
         lienergy[ie] = np.max(self.ienergygrid)*0.99
@@ -77,11 +77,7 @@ class RateNetworkGas(gas_properties.GasProperties):
         else:
             zgrid = self.tempgrid
 
-        # cast ONLY the vectors you pass into the C-extension
-        x32 = np.ascontiguousarray(ldensity[ii], dtype=np.float32)
-        y32 = np.ascontiguousarray(lienergy[ii], dtype=np.float32)
-
-        out[ii] = np.exp(_interpolate_2d(x32, y32, self.densgrid, self.ienergygrid, zgrid))
+        out[ii] = np.exp(_interpolate_2d(ldensity[ii], lienergy[ii], self.densgrid, self.ienergygrid, zgrid))
         ii2 = np.where(ldensity >= np.max(self.densgrid))
         return out,ii2,density,ienergy
 

--- a/fake_spectra/spectra.py
+++ b/fake_spectra/spectra.py
@@ -207,7 +207,7 @@ class Spectra:
             self.load_savefile(self.savefile)
 
         # Conversion factors from internal units
-        self.rscale = (self.units.UnitLength_in_cm*self.atime)/self.hubble
+        self.rscale = np.float32((self.units.UnitLength_in_cm*self.atime)/self.hubble)
         #Convert comoving internal units to physical km/s.
         if self.Hz is None:
             #Assume flat LCDM cosmology to compute H(z) (in km/s/Mpc)


### PR DESCRIPTION
I was playing around with @qezlou 2023 version [tutorial notebook](https://colab.research.google.com/github/DataDrivenGalaxyEvolution/galevo23-tutorials/blob/main/week-1/Large_scale_galaxy_formation_simulations_and_machine_learning_approaches_Part1_Simulated_absorption_spectra.ipynb) on Colab.
And when running these
```python
from fake_spectra.randspectra import RandSpectra

rr = RandSpectra(num=20, base="./MP-Gadget_L15n256/", numlos=3, thresh=0., res=5., savefile='spectra.hdf5')
# num is the snapshot number, i.e. PART_020
# numlos is the number of randomly positioned spectra you want
# pass thresh=0, otherwise only spectra with total column density above `thresh` are kept
# we set the pixel resolution 5 km/s
rr.get_tau(elem="H",ion=1,line=1215) # ion=1 refers to neutral gas, i.e. HI
                                     # line refers to the wavelength in Ansgtstrom
```
it returns

```
[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in _really_load_array(self, key, array, array_name)
    361         #First check it was not already loaded
--> 362         if np.size(array[key]) > 1:
    363             return

KeyError: ('H', 1, 1215)

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
[/tmp/ipython-input-2787844910.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in <cell line: 0>()
      6 # pass thresh=0, otherwise only spectra with total column density above `thresh` are kept
      7 # we set the pixel resolution 5 km/s
----> 8 rr.get_tau(elem="H",ion=1,line=1215) # ion=1 refers to neutral gas, i.e. HI
      9                                      # line refers to the wavelength in Ansgtstrom
     10 #Lyman-beta

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in get_tau(self, elem, ion, line, number, force_recompute)
    887             tau = self.tau[(elem, ion, line)]
    888         except KeyError:
--> 889             tau = self.compute_spectra(elem, ion, line, True)
    890             self.tau[(elem, ion, line)] = tau
    891         if number >= 0:

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in compute_spectra(self, elem, ion, ll, get_tau)
    815         if arepo :
    816             nsegments=1
--> 817         result = self._interpolate_single_file(0, elem, ion, ll, get_tau, load_all_data_first=arepo)
    818         #Do remaining files
    819         for nn in xrange(1, nsegments):

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in _interpolate_single_file(self, nsegment, elem, ion, ll, get_tau, load_all_data_first)
    546             line = self.lines[("H", 1)][1215]
    547         # print(pos.shape, vel.shape, elem_den.shape, temp.shape, hh.shape, amumass)
--> 548         return self._do_interpolation_work(pos, vel, elem_den, temp, hh, amumass, line, get_tau)
    549 
    550     def _read_particle_data(self, fn, elem, ion, get_tau):

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in _do_interpolation_work(self, pos, vel, elem_den, temp, hh, amumass, line, get_tau)
    671         else:
    672             gamma_X = line.gamma_X
--> 673         return _Particle_Interpolate(get_tau*1, self.nbins, self.kernel_int, self.box, self.velfac, self.atime, line.lambda_X*1e-8, gamma_X, line.fosc_X, amumass, self.tautail, pos, vel, elem_den, temp, hh, self.axis, self.cofm)
    674 
    675     def particles_near_lines(self, pos, hh, axis=None, cofm=None):

TypeError: One of the data arrays does not have 32-bit float type
```

and for the `ratenetworkspectra.py`

when running

```python
from fake_spectra.randspectra import RandSpectra

rr = RandSpectra(num=20, base="./MP-Gadget_L15n256/", numlos=3, thresh=0., res=5., savefile='spectra.hdf5')
# num is the snapshot number, i.e. PART_020
# numlos is the number of randomly positioned spectra you want
# pass thresh=0, otherwise only spectra with total column density above `thresh` are kept
# we set the pixel resolution 5 km/s
rr.get_tau(elem="H",ion=1,line=1215) # ion=1 refers to neutral gas, i.e. HI
                                     # line refers to the wavelength in Ansgtstrom
#Lyman-beta
rr.get_tau(elem="H",ion=1,line=1025)
rr.get_col_density("H",1)
#Save spectra to file
rr.save_file()
```

the 32-bit error shows up also

```bash
Reloading from snapshot (will save to:  ./MP-Gadget_L15n256/SPECTRA_020/spectra.hdf5  )
3  sightlines. resolution:  5.0079465240996  z= 2.1999999999999975
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in get_tau(self, elem, ion, line, number, force_recompute)
    885                 raise KeyError
--> 886             self._really_load_array((elem, ion, line), self.tau, "tau")
    887             tau = self.tau[(elem, ion, line)]

5 frames
[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in _really_load_array(self, key, array, array_name)
    361         #First check it was not already loaded
--> 362         if np.size(array[key]) > 1:
    363             return

KeyError: ('H', 1, 1215)

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
[/tmp/ipython-input-2787844910.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in <cell line: 0>()
      6 # pass thresh=0, otherwise only spectra with total column density above `thresh` are kept
      7 # we set the pixel resolution 5 km/s
----> 8 rr.get_tau(elem="H",ion=1,line=1215) # ion=1 refers to neutral gas, i.e. HI
      9                                      # line refers to the wavelength in Ansgtstrom
     10 #Lyman-beta

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in get_tau(self, elem, ion, line, number, force_recompute)
    887             tau = self.tau[(elem, ion, line)]
    888         except KeyError:
--> 889             tau = self.compute_spectra(elem, ion, line, True)
    890             self.tau[(elem, ion, line)] = tau
    891         if number >= 0:

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in compute_spectra(self, elem, ion, ll, get_tau)
    815         if arepo :
    816             nsegments=1
--> 817         result = self._interpolate_single_file(0, elem, ion, ll, get_tau, load_all_data_first=arepo)
    818         #Do remaining files
    819         for nn in xrange(1, nsegments):

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in _interpolate_single_file(self, nsegment, elem, ion, ll, get_tau, load_all_data_first)
    546             line = self.lines[("H", 1)][1215]
    547         # print(pos.shape, vel.shape, elem_den.shape, temp.shape, hh.shape, amumass)
--> 548         return self._do_interpolation_work(pos, vel, elem_den, temp, hh, amumass, line, get_tau)
    549 
    550     def _read_particle_data(self, fn, elem, ion, get_tau):

[/usr/local/lib/python3.12/dist-packages/fake_spectra/spectra.py](https://0fox435cw3k-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-external_20260212-060056_RC00_869112598#) in _do_interpolation_work(self, pos, vel, elem_den, temp, hh, amumass, line, get_tau)
    671         else:
    672             gamma_X = line.gamma_X
--> 673         return _Particle_Interpolate(get_tau*1, self.nbins, self.kernel_int, self.box, self.velfac, self.atime, line.lambda_X*1e-8, gamma_X, line.fosc_X, amumass, self.tautail, pos, vel, elem_den, temp, hh, self.axis, self.cofm)
    674 
    675     def particles_near_lines(self, pos, hh, axis=None, cofm=None):

TypeError: One of the data arrays does not have 32-bit float type
```

---
## Cause

I check the types of `pos, vel, elem_den, temp, hh` and elem_den returns float64 instead of 32, causing mismatch.
Simliar for ratenetworkspectra.py there are mismatch in density and lienergy.

I suspect somewhere in the code the float32 rule is more strict than 2023 version (or maybe numpy is more restrict), but I am not familiar with the code enough to pinpoint that. So perhaps there are multiple occurrences need to patch

## Fix

Current fix for me is change the dtype of `self.rscale` from float64 to float32, so it won't affect the downstream `elem_den`.
And for `ratenetworkspectra.py` the fix is making these two float32
```python
       ldensity = np.log(density).astype(np.float32, copy=False)
        lienergy = np.log(ienergy).astype(np.float32, copy=False)
```
copy false intentionally avoid creating new copy.

In case it's helpful, this is the [notebook](https://colab.research.google.com/drive/1f0foFXJRgbeHg0_nwMJm28T0PVVf3IFS?usp=sharing) to run on my branch.